### PR TITLE
Update relevant agents

### DIFF
--- a/data/scenario_tensor_converter_utils.py
+++ b/data/scenario_tensor_converter_utils.py
@@ -109,7 +109,7 @@ def min_distance_between_tracks(track_1: Track, track_2: Track) -> float:
     for track_1_os, track_2_os in zip(padded_object_state_iterator(track_1), padded_object_state_iterator(track_2)):
         if track_1_os is None or track_2_os is None:
             continue
-        min_dist = min(min_dist, distance_between_object_states(track_1_os, track_os_2))
+        min_dist = min(min_dist, distance_between_object_states(track_1_os, track_2_os))
     return min_dist
 
 """


### PR DESCRIPTION
This PR updates the what we consider to be relevant agents. Instead of just looking at the agents closest to ego at the first time step, take each track and compare it to the full length of Hero's track and find the minimum distance between the two from the full comparison. That minimum distance then serves as the priority for each track.